### PR TITLE
增加对于非文件类消息的加密强度

### DIFF
--- a/injects/core/AES.js
+++ b/injects/core/AES.js
@@ -34,7 +34,6 @@ function encrypt(text, key, iv_length, buffType = "hex", isFile = false) {
 }
 
 function decrypt(text, key, iv_length, buffType = "hex") {
-  console.log(text, key, "decrypt");
   let iv;
   if (text.includes(":")) {
     let textParts = text.split(":");

--- a/injects/core/AES.js
+++ b/injects/core/AES.js
@@ -5,24 +5,53 @@ const { promisify } = require('util');
 const crypto = require("crypto");
 const algorithm = "aes-256-ctr";
 
+function randomString(e) {    
+    e = e || 32;
+    var t = "ABCDEFGHJKMNPQRSTWXYZabcdefhijkmnprstwxyz2345678",
+    a = t.length,
+    n = "";
+    for (i = 0; i < e; i++) n += t.charAt(Math.floor(Math.random() * a));
+    return n
+}
 
-function encrypt(text, key, iv_length, buffType = "hex") {
-  // let iv = crypto.randomBytes(iv_length);
-  let iv = key.substring(0, iv_length);
+function encrypt(text, key, iv_length, buffType = "hex", isFile = false) {
+  let iv;
+  if(isFile) {
+    iv = key.substring(0, iv_length);
+  }
+  else {
+    iv = randomString(iv_length);
+  }
   let cipher = crypto.createCipheriv(algorithm, key, iv);
   let encrypted = cipher.update(text);
   encrypted = Buffer.concat([encrypted, cipher.final()]);
-  return encrypted.toString(buffType);
+  if(isFile) {
+    return encrypted.toString(buffType);
+  }
+  else {
+    return iv + "*" + encrypted.toString(buffType);
+  }
 }
 
 function decrypt(text, key, iv_length, buffType = "hex") {
+  console.log(text, key, "decrypt");
   let iv;
   if (text.includes(":")) {
     let textParts = text.split(":");
     iv = Buffer.from(textParts.shift(), buffType);
     text = textParts[0];
   } else {
-    iv = key.substring(0, iv_length);
+    if(text.includes("*"))
+    {
+      let textParts = text.split("*");
+      iv = textParts[0];
+      text = textParts[1];
+      console.log(iv, text)
+    }
+    else
+    {
+      iv = key.substring(0, iv_length);
+    }
   }
   let encryptedText = Buffer.from(text, buffType);
   let decipher = crypto.createDecipheriv(algorithm, key, iv);

--- a/injects/main.js
+++ b/injects/main.js
@@ -248,7 +248,7 @@ async function onLoad(plugin) {
       }
 
       const pathInfo = path.parse(filePath);
-      const encryptName = `pge-${AES.encrypt(pathInfo.name + pathInfo.ext, key, iv.length)}`;
+      const encryptName = `pge-${AES.encrypt(pathInfo.name + pathInfo.ext, key, iv.length, "hex", true)}`;
       const encryptFilePath = path.join(fileDir, encryptName);
 
       await AES.encryptFile(filePath, encryptFilePath, key, iv);


### PR DESCRIPTION
对于非文件类消息，采用每个消息随机生成iv并通过*来附着在消息前，以加强AES加密的强度：在消息内容相同时，由于iv不同，加密结果完全不同；并且如果iv固定，攻击者很可能根据多次加密的结果来破解密钥。